### PR TITLE
[BS-1] Add current year to footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "google-map-react": "^2.2.1",
     "helmet": "^6.0.1",
     "i18next": "^23.11.2",
+    "luxon": "^3.5.0",
     "notistack": "^2.0.8",
     "react": "^18.2.0",
     "react-card-flip": "^1.1.5",

--- a/src/components/footer/Copyright.js
+++ b/src/components/footer/Copyright.js
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import { Box, styled, Typography } from "@mui/material";
 
 // -------------------------------------------------------------------------
@@ -17,10 +18,12 @@ const TypographyStyled = styled(Typography)(({ theme }) => ({
 // -------------------------------------------------------------------------
 
 export default function Copyright() {
+  const currentYear = DateTime.now().year;
+
   return (
     <BoxStyled>
       <TypographyStyled>
-        ©2023. BLACKSTOCK
+        ©{currentYear}. BLACKSTOCK
       </TypographyStyled>
     </BoxStyled>
   );


### PR DESCRIPTION
# [[BS-1] Show current year in footer](https://blackstock.atlassian.net/browse/BS-1)

## Description
The footer of the application needs to display the current year dynamically in the format: © [current year]. BLACKSTOCK. This ensures the year is always up-to-date, eliminating the need for manual updates each year.

## Steps to Reproduce
1. Open the application in any browser or device.
2. Scroll to the footer section of the application page.
3. Verify the year displayed in the footer (it may be static or outdated).
4. Confirm that the footer does not automatically update the year when a new year begins.

## Expected Behavior
- The footer should display the current year dynamically in the format: © [current year]. BLACKSTOCK (e.g., © 2024. BLACKSTOCK).
- The year should automatically update at the start of each new year without requiring manual changes.
- If the year is already displayed in the footer, it should reflect the correct current year when the page is loaded.

## Screenshots
![image](https://github.com/user-attachments/assets/12500fe2-685b-43db-901f-0403921eb8e3)
